### PR TITLE
Fix SCA vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,9 +1834,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://nexus.luigi.worldpay.io/repository/npm-all/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://nexus.luigi.worldpay.io/repository/npm-all/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5279,9 +5279,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://nexus.luigi.worldpay.io/repository/npm-all/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://nexus.luigi.worldpay.io/repository/npm-all/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "overrides": {
     "express": {
       "qs": "^6.14.2"
+    },
+    "@modelcontextprotocol/sdk": {
+      "ajv": "^8.18.0"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
     "node-fetch": "^3.3.2",
     "winston": "^3.17.0"
   },
+  "overrides": {
+    "express": {
+      "qs": "^6.14.2"
+    }
+  },
   "devDependencies": {
     "@fetch-mock/jest": "^0.2.20",
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
### What
- patch qs and ajv transitive dependencies

### Why
- express and @modelcontextprotocol/sdk have not yet released new versions to that include these dependencies