### PR TITLE
docs: Add MerchantGuard MCP as companion fraud scoring layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,30 @@ An example configuration file is given.
         }
 ```
 
+
+
+## Companion Tools
+
+### MerchantGuard MCP — Fraud Scoring for Agentic Commerce
+
+Use [MerchantGuard MCP](https://github.com/MerchantGuardOps/merchantguard-mcp) alongside Worldpay MCP to add AI-native fraud scoring to every agent transaction. MerchantGuard provides:
+
+- **Transaction Risk Scoring** — Score transactions for fraud risk before processing payment
+- **Agent Verification** — Verify AI agent trustworthiness and authorization levels
+- **Cross-Rail Fraud Detection** — Detect fraud patterns across card, stablecoin, and crypto rails
+- **VAMP Analysis** — Monitor Visa Acquirer Monitoring Program compliance
+
+```json
+{
+  "mcpServers": {
+    "merchantguard": {
+      "command": "node",
+      "args": ["/path/to/merchantguard-mcp/dist/server-stdio.js"]
+    },
+    "worldpay": {
+      "command": "node",
+      "args": ["/path/to/worldpay-mcp/dist/server-stdio.js"]
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary

- Adds a "Companion Tools" section to the README documenting [MerchantGuard MCP](https://github.com/MerchantGuardOps/merchantguard-mcp) as a fraud scoring layer that works alongside Worldpay MCP
- MerchantGuard MCP provides transaction risk scoring, AI agent verification, cross-rail fraud detection (card + stablecoin + crypto), and VAMP compliance monitoring
- Includes a combined `mcpServers` configuration example showing both servers side by side

This is a docs-only change — no code modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)